### PR TITLE
Add asset_match filter to netkan file

### DIFF
--- a/KSPDev_LogConsole.netkan
+++ b/KSPDev_LogConsole.netkan
@@ -11,7 +11,7 @@
     "license"        : "public-domain",
     "author"         : ["IgorZ"],
     "$vref"          : "#/ckan/ksp-avc",
-    "$kref"          : "#/ckan/github/ihsoft/KSPDev",
+    "$kref"          : "#/ckan/github/ihsoft/KSPDev/asset_match/KSPDev_LogConsole_*",
     "x_netkan_version_edit" : "^logconsole_(?<version>.+)$",
     "x_netkan_epoch" : "1",
     "install"        : [


### PR DESCRIPTION
This NetKAN's Github repo and its release listing are shared by 4 projects, only one of which (`KSPDev_LogConsole`) is supposed to be inflated by this NetKAN. Currently the correct zip files are selected based on the `x_netkan_version_edit` field; each of the mods uses a custom version format, and only versions matching `logconsole_X.Y.Z` are parsed correctly. However, this also means that when one of the other projects is the latest release in the listing, it is chosen as the latest release, but then errors out due to the mismatched version. This is why the [status page](http://status.ksp-ckan.org/) says "Could not match version with find pattern" for KSPDev_LogConsole even though no versions of it are missing.

I was thinking it would be helpful to add a pattern filter to do this sort of selection more cleanly, and lo and behold, when I started to dig into the code to figure out how, it was already there! You can append `/asset_match/` to the `$kref` followed by a glob pattern, and only downloads matching that pattern will be used; this has the advantage of ignoring non-matching releases completely rather than generating spurious errors. 51 mods are already making use of this method.

(Note that the `x_netkan_version_edit` field is probably still necessary to convert the version numbers to the correct format, it just won't be used for download filtering anymore, and so the errors for this mod should go away.)